### PR TITLE
feat: Log 컴포넌트에서 투기 이미지 삭제 기능 구현 및 확인 모달 추가

### DIFF
--- a/service/src/pages/mainPage/components/log/ConfirmModal.js
+++ b/service/src/pages/mainPage/components/log/ConfirmModal.js
@@ -1,0 +1,23 @@
+import React from "react";
+import "./ConfirmModal.scss";
+
+export default function ConfirmModal({ onConfirm, onCancel }) {
+    return (
+        <div className="confirm-background">
+            <div className="confirm-box">
+                <div className="confirm-text">
+                    <span>선택한 이미지 데이터를</span>
+                    <span>영구적으로 삭제하시겠습니까?</span>
+                </div>
+                <div className="confirm-buttons">
+                    <button className="confirm-button" onClick={onCancel}>
+                        취소
+                    </button>
+                    <button className="cancel-button" onClick={onConfirm}>
+                        영구삭제
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/service/src/pages/mainPage/components/log/ConfirmModal.scss
+++ b/service/src/pages/mainPage/components/log/ConfirmModal.scss
@@ -1,0 +1,68 @@
+@import "src/assets/styles/index.scss";
+
+.confirm-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.confirm-box {
+    width: 23%;
+    height: 23%;
+    background: white;
+    padding: 20px;
+    border-radius: 28px;
+    text-align: center;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.confirm-text {
+    width: auto;
+    height: auto;
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+
+    span {
+        height: 20px;
+        font-size: 15px;
+        font-weight: 600;
+    }
+}
+
+.confirm-buttons {
+    margin-top: 25px;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    font-size: 20px;
+}
+
+.confirm-button {
+    width: 35%;
+    height: 25%;
+    background: $edit-hover;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.cancel-button {
+    width: 35%;
+    height: 25%;
+    background: $delete-hover;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/service/src/pages/mainPage/components/log/FeedbackModal.js
+++ b/service/src/pages/mainPage/components/log/FeedbackModal.js
@@ -1,8 +1,7 @@
 import "./FeedbackModal.scss";
-import checkMark from "../../../../assets/images/check_mark.png";
 import { useEffect } from "react";
 
-export default function FeedbackModal(onClose) {
+export default function FeedbackModal({ onClose, text1, text2, imgSrc }) {
     useEffect(() => {
         // 3초 후에 자동으로 모달 닫기
         const timer = setTimeout(() => {
@@ -15,10 +14,10 @@ export default function FeedbackModal(onClose) {
 
     return (
         <div className="feedback-box">
-            <img src={checkMark} alt="이미지" />
+            <img src={imgSrc} alt="이미지" />
             <div className="feedback-box-span-box">
-                <span>정상적으로 처리되었습니다.</span>
-                <span>감사합니다 :)</span>
+                <span>{text1}</span>
+                <span>{text2}</span>
             </div>
         </div>
     );

--- a/service/src/pages/mainPage/components/log/FeedbackModal.scss
+++ b/service/src/pages/mainPage/components/log/FeedbackModal.scss
@@ -4,6 +4,7 @@
     z-index: 1000;
     position: fixed;
     top: 1.5%;
+    left: 41%;
     background-color: #fff;
     border: none;
     border-radius: 12px;

--- a/service/src/pages/mainPage/components/log/Log.js
+++ b/service/src/pages/mainPage/components/log/Log.js
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from "react";
 import countryHouseIcon from "../../../../assets/images/country_house.png";
+import checkMark from "../../../../assets/images/check_mark.png";
+import trashCan from "../../../../assets/images/trash_can.png";
 import LogList from "./LogList";
 import FeedbackModal from "./FeedbackModal";
+import ConfirmModal from "./ConfirmModal";
 import api from "../../../../api/api";
 import "./Log.scss";
 
@@ -11,12 +14,17 @@ export default function Log({
     multiView,
     dumpingData,
     setSelectedCCTV,
+    roleName,
 }) {
     const [checkedItems, setCheckedItems] = useState([]);
     const [filteredImages, setFilteredImages] = useState([]);
     const cctvId = selectedCCTV ? selectedCCTV.cctvId : null;
     // const [dumpingEvent, setDumpingEvent] = useState([]);
     const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+    const [text1, setText1] = useState("");
+    const [text2, setText2] = useState("");
+    const [imgSrc, setImgSrc] = useState("");
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
 
     useEffect(() => {
         // 멀티뷰일 경우, 모든 투기 데이터를 보여줌
@@ -35,23 +43,8 @@ export default function Log({
         }
     }, [multiView, dumpingData, cctvId]);
 
-    // useEffect(() => {
-    //     console.log(
-    //         "multiView: ",
-    //         multiView,
-    //         "\n",
-    //         "selectedCCTV: ",
-    //         selectedCCTV,
-    //         "\n",
-    //         "cctvId: ",
-    //         cctvId,
-    //         "\n",
-    //         "filteredImages: ",
-    //         filteredImages
-    //     );
-    // }, [filteredImages]);
-
-    const handleClassificationError = () => {
+    // 분류 오류 이벤트를 처리하는 함수수
+    const handleClassificationError = async () => {
         if (checkedItems.length === 0) {
             alert("선택된 항목이 없습니다.");
             return;
@@ -62,47 +55,162 @@ export default function Log({
             .filter((item) => !checkedItems.includes(item.imageId))
             .map((item) => item.imageId);
 
-        // 실패한 이미지 삭제 및 로그 저장
-        const deleteFailImages = api.delete("/cleanguard/image/fail", {
-            data: checkedItems,
-        });
-
-        // 성공한 이미지 로그 저장
-        const saveSuccessImages = successItems.length
-            ? api.delete("/cleanguard/image/success", { data: successItems })
-            : Promise.resolve(); // 성공 이미지가 없으면 요청 안 보냄
-
-        Promise.all([deleteFailImages, saveSuccessImages])
-            .then(([failResponse, successResponse]) => {
-                console.log("분류 오류 처리 성공:", failResponse.data);
-                if (successItems.length) {
-                    console.log("성공 로그 저장 성공:", successResponse.data);
+        try {
+            // 실패한 이미지 삭제 요청
+            const deleteFailImages = await api.delete(
+                "/cleanguard/image/fail",
+                {
+                    params: { imageIds: checkedItems },
+                    paramsSerializer: (params) => {
+                        return Object.keys(params)
+                            .map((key) =>
+                                []
+                                    .concat(params[key])
+                                    .map(
+                                        (val) =>
+                                            `${key}=${encodeURIComponent(val)}`
+                                    )
+                                    .join("&")
+                            )
+                            .join("&");
+                    },
                 }
+            );
 
-                setShowFeedbackModal(true); // 성공 모달 표시
+            console.log("fail 삭제 응답:", deleteFailImages.data);
 
-                // 최신 데이터 다시 가져오기
-                api.get("/cleanguard/image/user")
-                    .then((response) => {
-                        setFilteredImages(response.data); // 리스트 업데이트
-                        setCheckedItems([]); // 선택된 항목 초기화
-                        console.log("목록 갱신 성공:", response.data);
-                    })
-                    .catch((error) => {
-                        console.error("목록 갱신 실패:", error);
-                    });
-            })
-            .catch((error) => {
-                console.error("분류 오류 처리 실패:", error);
-                alert("오류가 발생했습니다. 다시 시도해주세요.");
+            // 성공한 이미지 post 요청
+            let successResponse = null;
+            if (successItems.length) {
+                try {
+                    successResponse = await api.post(
+                        "/cleanguard/image/success",
+                        null, // body를 비워두고 params로 데이터를 전달
+                        {
+                            params: { imageIds: successItems },
+                            paramsSerializer: (params) => {
+                                return Object.keys(params)
+                                    .map((key) =>
+                                        []
+                                            .concat(params[key])
+                                            .map(
+                                                (val) =>
+                                                    `${key}=${encodeURIComponent(
+                                                        val
+                                                    )}`
+                                            )
+                                            .join("&")
+                                    )
+                                    .join("&");
+                            },
+                            headers: {
+                                "Content-Type": "application/json",
+                            },
+                        }
+                    );
+                    console.log("success 저장 응답:", successResponse.data);
+                } catch (error) {
+                    console.error("Success 이미지 저장 실패:", error);
+                    console.log("서버 응답:", error.response?.data);
+                    alert(
+                        `Success 저장 실패: ${
+                            error.response?.data?.message || error.message
+                        }`
+                    );
+                }
+            }
+
+            setText1("정상적으로 처리되었습니다.");
+            setText2("감사합니다 :)");
+            setImgSrc(checkMark);
+
+            setShowFeedbackModal(true); // 성공 모달 표시
+
+            // 최신 데이터 다시 가져오기
+            if (roleName) {
+                const response = await api.get(`/cleanguard/image/${roleName}`);
+                setFilteredImages(response.data);
+                setCheckedItems([]); // 선택된 항목 초기화
+                console.log("목록 갱신 성공:", response.data);
+            }
+        } catch (error) {
+            console.error("분류 오류 처리 실패:", error);
+            alert("오류가 발생했습니다. 다시 시도해주세요.");
+        }
+    };
+
+    // 영구 삭제 이벤트를 처리하는 함수
+    const handlePermanentDelete = async () => {
+        if (checkedItems.length === 0) {
+            alert("선택된 항목이 없습니다.");
+            return;
+        }
+
+        try {
+            // 선택된 이미지 삭제 요청
+            const deleteResponse = await api.delete("/cleanguard/image/", {
+                params: { imageIds: checkedItems },
+                paramsSerializer: (params) => {
+                    return Object.keys(params)
+                        .map((key) =>
+                            []
+                                .concat(params[key])
+                                .map(
+                                    (val) => `${key}=${encodeURIComponent(val)}`
+                                )
+                                .join("&")
+                        )
+                        .join("&");
+                },
             });
+
+            console.log("영구 삭제 응답:", deleteResponse.data);
+
+            setText1("정상적으로 처리되었습니다.");
+            setText2("감사합니다 :)");
+            setImgSrc(trashCan);
+
+            setShowFeedbackModal(true);
+
+            // 목록 갱신
+            if (roleName) {
+                const response = await api.get(`/cleanguard/image/${roleName}`);
+                setFilteredImages(response.data);
+                setCheckedItems([]);
+                console.log("목록 갱신 성공:", response.data);
+            }
+        } catch (error) {
+            console.error("영구 삭제 실패:", error);
+            alert("오류가 발생했습니다. 다시 시도해주세요.");
+        }
+    };
+
+    const handleConfirmModal = () => {
+        setShowConfirmModal(true);
+    };
+
+    const handleConfirmDelete = () => {
+        setShowConfirmModal(false);
+        handlePermanentDelete();
     };
 
     return (
         <div className="viewer">
             {showFeedbackModal && (
-                <FeedbackModal onClose={() => setShowFeedbackModal(false)} />
+                <FeedbackModal
+                    onClose={() => setShowFeedbackModal(false)}
+                    text1={text1}
+                    text2={text2}
+                    imgSrc={imgSrc}
+                />
             )}
+            {showConfirmModal && (
+                <ConfirmModal
+                    onConfirm={handleConfirmDelete}
+                    onCancel={() => setShowConfirmModal(false)}
+                />
+            )}
+
             <div className="viewer-topbar">
                 <div className="viewer-title">
                     현재 CCTV:{" "}
@@ -127,6 +235,8 @@ export default function Log({
                     <button
                         className="viewer-button-group-action"
                         style={{ backgroundColor: "#AF0000" }}
+                        // onClick={handlePermanentDelete}
+                        onClick={handleConfirmModal}
                     >
                         영구 삭제
                     </button>

--- a/service/src/pages/mainPage/main.js
+++ b/service/src/pages/mainPage/main.js
@@ -63,6 +63,15 @@ function Main() {
                 .catch((error) => {
                     console.error("Dumping 데이터 가져오기 실패:", error);
                 });
+
+            //log 데이터 요청
+            api.get(`/cleanguard/log/${roleName}`)
+                .then((response) => {
+                    console.log("log 데이터 가져오기 성공:", response.data);
+                })
+                .catch((error) => {
+                    console.error("log 데이터 가져오기 실패:", error);
+                });
         }
     }, [roleName]);
 

--- a/service/src/pages/mainPage/main.js
+++ b/service/src/pages/mainPage/main.js
@@ -49,7 +49,6 @@ function Main() {
             })
             .catch((error) => {
                 console.error("CCTV 데이터 가져오기 실패:", error);
-
             });
     }, [window.location.search]);
 
@@ -94,6 +93,7 @@ function Main() {
                             onShowLog={() => setShowLog(false)}
                             multiView={multiView}
                             dumpingData={dumpingEvent}
+                            roleName={roleName}
                         />
                     ) : (
                         <>


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## #️⃣연관된 이슈

> #2  

## 반영 브랜치

> feat/delete-image -> dev


## 📝작업 내용

> 1. DELETE, POST API 연동: 사용자가 선택한 이미지를 삭제하거나 데이터를 보낼 수 있도록 /cleanguard/image/, /cleanguard/image/success, /cleanguard/image/fail API와 연동하였습니다. paramsSerializer를 사용하여 imageIds를 적절한 형식으로 변환하여 요청을 보냈습니다. 
(imageIds 배열을 imageIds=1&imageIds=2&imageIds=3 같은 형태로 변환)

> 2. 삭제 전 확인 모달 추가: 사용자가 실수로 삭제하는 것을 방지하기 위해 "선택한 이미지 데이터를 
영구적으로 삭제하시겠습니까?" 모달을 추가하였습니다. 영구삭제 누르면 삭제 요청이 진행되며, 취소를 누르면 요청이 중단됩니다.

>3. 삭제 후 화면 업데이트: 삭제가 완료된 후 최신 데이터를 가져와 리스트를 업데이트하여 삭제된 이미지가 즉시 반영되도록 처리하였습니다.

>4. 예외 처리: API 요청 실패 시 오류 메시지를 출력하고 사용자에게 알림을 표시하도록 구현하였습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/99452ead-dfb3-4a8c-be8e-d03f8b4b4806)

Close #2 