### PR TITLE
refactor: api 호출을 SSE로 변경하여 실시간 이미지 업데이트 구현

### DIFF
--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.9",
         "chart.js": "^4.4.6",
+        "event-source-polyfill": "^1.0.31",
         "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
@@ -8472,6 +8473,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",

--- a/service/package.json
+++ b/service/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.9",
     "chart.js": "^4.4.6",
+    "event-source-polyfill": "^1.0.31",
     "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",

--- a/service/src/api/api.js
+++ b/service/src/api/api.js
@@ -24,6 +24,7 @@ const scheduleRefresh = () => {
     // 이전 타이머가 있으면 제거
     if (refreshTimeoutId) {
         clearTimeout(refreshTimeoutId);
+        refreshTimeoutId = null;
     }
     const accessToken = localStorage.getItem("accessToken");
     if (!accessToken) return;
@@ -61,7 +62,7 @@ const refreshAccessToken = async () => {
             const refreshToken = localStorage.getItem("refreshToken");
             // refreshToken이 없으면 바로 로그아웃 처리
             if (!refreshToken) {
-                handleLogout();
+                await handleLogout();
                 console.log("유효한 refresh token이 없습니다.");
                 return;
             }
@@ -80,7 +81,7 @@ const refreshAccessToken = async () => {
         } catch (refreshError) {
             console.error("새 access Token 발급 실패:", refreshError);
             console.error("오류 세부 정보:", refreshError.response?.data);
-            handleLogout();
+            await handleLogout();
             reject(refreshError);
         } finally {
             refreshPromise = null;
@@ -142,7 +143,7 @@ const handleLogout = async () => {
         localStorage.removeItem("refreshToken");
         await api.get("/cleanguard/logout");
         console.log("로그아웃 완료");
-        window.location.href = "/signup";
+        //window.location.href = "/signup";
     } catch (error) {
         console.error("로그아웃 중 오류 발생:", error);
         // 로그아웃 요청 실패해도 클라이언트 측에서 강제 로그아웃 처리
@@ -152,6 +153,11 @@ const handleLogout = async () => {
 
 // 초기화 함수 ==> 앱 시작 시 호출
 const initAuth = () => {
+    if (refreshTimeoutId !== null) {
+        clearTimeout(refreshTimeoutId);
+        refreshTimeoutId = null;
+    }
+
     const accessToken = localStorage.getItem("accessToken");
     if (accessToken) {
         // 토큰이 있으면 자동 갱신 예약

--- a/service/src/pages/mainPage/main.js
+++ b/service/src/pages/mainPage/main.js
@@ -58,35 +58,56 @@ function Main() {
         if (roleName) {
             const accessToken = localStorage.getItem("accessToken");
             const sseUrl = `http://3.36.174.53:8080/cleanguard/image/sse/${roleName}`;
-            const eventSource = new EventSourcePolyfill(sseUrl, {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            });
+            let eventSource;
+            let reconnCount = 0;
 
-            eventSource.onopen = () => {
-                console.log("SSE 연결 성공");
-            };
+            const connect = () => {
 
-            eventSource.onmessage = (event) => {
-                try {
-                    const newData = JSON.parse(event.data); // 서버로부터 이미지 배열 전체가 옴
-                    setDumpingEvent((prev) => {
-                        // 중복되지 않는 새 이미지만 필터링하여 업데이트
-                        const existImage = new Set(prev.map((item) => item.imageId));
-                        const newImage = newData.filter((item) => !existImage.has(item.imageId));
-                        return [...prev, ...newImage];
-                    });
-                    console.log("이미지 데이터 가져오기 성공(SSE) :", newData);
-                } catch (error) {
-                    console.error("SSE 데이터 파싱 오류:", error);
+                // 재연결 시도 횟수 제한 -> 무한 연결 시도 방지
+                if (reconnCount >= 3) {
+                    console.log("SSE 재연결 최대 시도 횟수 초과(3회)");
+                    return;
                 }
+
+                eventSource = new EventSourcePolyfill(sseUrl, {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                    },
+                });
+
+                eventSource.onopen = () => {
+                    console.log("SSE 연결 성공");
+                    reconnCount = 0;
+                };
+
+                eventSource.onmessage = (event) => {
+                    try {
+                        const newData = JSON.parse(event.data); // 서버로부터 이미지 배열 전체가 옴
+                        setDumpingEvent((prev) => {
+                            // 중복되지 않는 새 이미지만 필터링하여 업데이트
+                            const existImage = new Set(prev.map((item) => item.imageId));
+                            const newImage = newData.filter((item) => !existImage.has(item.imageId));
+                            return [...prev, ...newImage];
+                        });
+                        console.log("이미지 데이터 가져오기 성공(SSE) :", newData);
+                    } catch (error) {
+                        console.error("SSE 데이터 파싱 오류:", error);
+                    }
+                };
+
+                eventSource.onerror = (error) => {
+                    console.error("SSE 연결 오류:", error);
+                    eventSource.close();
+                    reconnCount += 1;
+                    setTimeout(() => {
+                        console.log("SSE 재연결 시도");
+                        connect();
+                    }, 1000); // 1초 후 재연결 시도
+                };
             };
 
-            eventSource.onerror = (error) => {
-                console.error("SSE 연결 오류:", error);
-                eventSource.close(); 
-            };
+            // 초기 연결
+            connect();
 
             // 컴포넌트 언마운트 시 SSE 연결 종료
             return () => {
@@ -94,6 +115,7 @@ function Main() {
                 console.log("SSE 연결 종료");
             };
         }
+
     }, [roleName]);
 
 

--- a/service/src/pages/mainPage/main.js
+++ b/service/src/pages/mainPage/main.js
@@ -11,6 +11,7 @@ import AddModal from "./components/cctvSidemenu/AddModal";
 import EditModal from "./components/cctvSidemenu/EditModal";
 import DeleteModal from "./components/cctvSidemenu/DeleteModal";
 import api from "../../api/api"; // axios 인스턴스 호출
+import { EventSourcePolyfill } from 'event-source-polyfill';
 
 function Main() {
     const [dumpingEvent, setDumpingEvent] = useState([]);
@@ -53,17 +54,51 @@ function Main() {
     }, [window.location.search]);
 
     useEffect(() => {
-        // image 데이터 요청
+        // image 데이터 요청(SSE)
         if (roleName) {
-            api.get(`/cleanguard/image/${roleName}`)
-                .then((response) => {
-                    setDumpingEvent(response.data);
-                    console.log("Dumping 데이터 가져오기 성공:", response.data);
-                })
-                .catch((error) => {
-                    console.error("Dumping 데이터 가져오기 실패:", error);
-                });
+            const accessToken = localStorage.getItem("accessToken");
+            const sseUrl = `http://3.36.174.53:8080/cleanguard/image/sse/${roleName}`;
+            const eventSource = new EventSourcePolyfill(sseUrl, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            });
 
+            eventSource.onopen = () => {
+                console.log("SSE 연결 성공");
+            };
+
+            eventSource.onmessage = (event) => {
+                try {
+                    const newData = JSON.parse(event.data); // 서버로부터 이미지 배열 전체가 옴
+                    setDumpingEvent((prev) => {
+                        // 중복되지 않는 새 이미지만 필터링하여 업데이트
+                        const existImage = new Set(prev.map((item) => item.imageId));
+                        const newImage = newData.filter((item) => !existImage.has(item.imageId));
+                        return [...prev, ...newImage];
+                    });
+                    console.log("이미지 데이터 가져오기 성공(SSE) :", newData);
+                } catch (error) {
+                    console.error("SSE 데이터 파싱 오류:", error);
+                }
+            };
+
+            eventSource.onerror = (error) => {
+                console.error("SSE 연결 오류:", error);
+                eventSource.close(); 
+            };
+
+            // 컴포넌트 언마운트 시 SSE 연결 종료
+            return () => {
+                eventSource.close();
+                console.log("SSE 연결 종료");
+            };
+        }
+    }, [roleName]);
+
+
+    useEffect(() => {
+        if (roleName) {
             //log 데이터 요청
             api.get(`/cleanguard/log/${roleName}`)
                 .then((response) => {


### PR DESCRIPTION

## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 
## 연관된 이슈
X
## 반영 브랜치 

feat/replace-api-sse -> dev

## 작업 내용
1. 기존 이미지 API 호출 방식을 SSE로 변경하여 실시간 이미지 업데이트 구현
2.  event-source-polyfill 라이브러리를 사용해 SSE 연결 설정 
-> 헤더에 엑세스 토큰 추가 가능
4. 중복 이미지 필터링 로직을 추가하여 데이터 중복 방지
- 서버에서 약 5초마다 전체 이미지 데이터 배열을 보내주는 상태. 
- 이런 경우 동일한 이미지가 중복되어 추가되는 문제가 발생함.
- 따라서 아래와 같은 로직 추가

![image](https://github.com/user-attachments/assets/741841b4-8ab2-41fc-bc11-0a49c947c789)



## 스크린샷 (선택)















