### PR TITLE
feat: 반응형 웹 구현 및 미디어 쿼리 작성

### DIFF
--- a/service/src/assets/styles/breakpoints.scss
+++ b/service/src/assets/styles/breakpoints.scss
@@ -1,0 +1,20 @@
+// 모바일
+$breakpoint-mobile: 335px;
+
+// 모바일에서 태블릿
+$breakpoint-tabletToMobile: 535px;
+
+// 태블릿
+$breakpoint-tablet: 720px;
+
+// 태블릿에서 노트북
+$breakpoint-laptopToTablet: 960px;
+
+// 노트북
+$breakpoint-laptop: 1024px;
+
+// 노트북에서 데스크탑
+$breakpoint-desktopToLaptop: 1500px;
+
+// 데스크탑
+$breakpoint-desktop: 1800px;

--- a/service/src/assets/styles/index.scss
+++ b/service/src/assets/styles/index.scss
@@ -1,5 +1,5 @@
-@import './color.scss';
-@import './font.scss';
-@import './mixins.scss';
-@import '~slick-carousel/slick/slick.css';
-@import '~slick-carousel/slick/slick-theme.css';
+@import "./color.scss";
+@import "./font.scss";
+@import "./mixins.scss";
+@import "~slick-carousel/slick/slick.css";
+@import "~slick-carousel/slick/slick-theme.css";

--- a/service/src/assets/styles/mixins.scss
+++ b/service/src/assets/styles/mixins.scss
@@ -1,0 +1,58 @@
+@import "./breakpoints.scss";
+
+// 모바일 : 335px ~ 535px
+// 모바일에서 태블릿 : 535px ~ 720px
+// 태블릿 : 720px ~ 960px
+// 태블릿에서 노트북 : 960px ~ 1024px
+// 노트북 : 1024px ~ 1500px
+// 노트북에서 데스크탑 : 1500px ~ 1800px
+// 데스크탑 : 1800px ~
+
+// 모바일 : 최소 '모바일'사이즈부터 ~ 최대 '모바일에서 태블릿'사이즈까지
+@mixin mobile {
+    @media (min-width: #{$breakpoint-mobile}) and (max-width: #{$breakpoint-tabletToMobile - 1px}) {
+        @content;
+    }
+}
+
+// 모바일에서 태블릿 : 최소 '모바일에서 태블릿'사이즈부터 ~ 최대 '태블릿'사이즈까지
+@mixin tabletToMobile {
+    @media (min-width: #{$breakpoint-tabletToMobile}) and (max-width: #{$breakpoint-tablet - 1px}) {
+        @content;
+    }
+}
+
+// 태블릿 : 최소'태블릿'사이즈부터 ~ 최대 '태블릿에서 노트북'사이즈까지
+@mixin tablet {
+    @media (min-width: #{$breakpoint-tablet}) and (max-width: #{$breakpoint-laptopToTablet - 1px}) {
+        @content;
+    }
+}
+
+// 태블릿에서 노트북 : 최소 '태블릿에서 노트북'사이즈부터 ~ 최대 '노트북'사이즈까지
+@mixin laptopToTablet {
+    @media (min-width: #{$breakpoint-laptopToTablet}) and (max-width: #{$breakpoint-laptop - 1px}) {
+        @content;
+    }
+}
+
+// 노트북 : 최소 '노트북'사이즈부터 ~ 최대 '노트북에서 데스크탑'사이즈까지
+@mixin laptop {
+    @media (min-width: #{$breakpoint-laptop}) and (max-width: #{$breakpoint-desktopToLaptop - 1px}) {
+        @content;
+    }
+}
+
+// 노트북에서 데스크탑 : 최소 '노트북에서 데스크탑'사이즈부터 ~ 최대 '데스크탑'사이즈까지
+@mixin desktopToLaptop {
+    @media (min-width: #{$breakpoint-desktopToLaptop}) and (max-width: #{$breakpoint-desktop - 1px}) {
+        @content;
+    }
+}
+
+// 데스크탑 : 최소 '데스크탑'사이즈
+@mixin desktop {
+    @media (min-width: #{$breakpoint-desktop}) {
+        @content;
+    }
+}

--- a/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.js
+++ b/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.js
@@ -40,26 +40,26 @@ function CCTVSidemenu({
                             onMouseLeave={handleMouseLeave}
                         >
                             {cctv.cctvName} ({cctv.location})
-                            {hoveredCCTV === cctv && showPopup === true && (
-                                <div className="popup">
-                                    <div onClick={() => setShowAddModal(true)}>
-                                        추가
-                                    </div>
-                                    <div onClick={() => setShowEditModal(true)}>
-                                        수정
-                                    </div>
-                                    <div
-                                        onClick={() => setShowDeleteModal(true)}
-                                    >
-                                        삭제
-                                    </div>
-                                    {/* 상세페이지로 이동했을 경우에만, '상세 기록' 옵션 추가되도록
-                                        ==> 상세페이지 생성 이후 기능 구현 예정*/}
-                                    <div onClick={() => setShowLog(true)}>
-                                        상세 기록
-                                    </div>
+                            <div
+                                className={`popup ${
+                                    hoveredCCTV === cctv && showPopup
+                                        ? "visible"
+                                        : ""
+                                }`}
+                            >
+                                <div onClick={() => setShowAddModal(true)}>
+                                    추가
                                 </div>
-                            )}
+                                <div onClick={() => setShowEditModal(true)}>
+                                    수정
+                                </div>
+                                <div onClick={() => setShowDeleteModal(true)}>
+                                    삭제
+                                </div>
+                                <div onClick={() => setShowLog(true)}>
+                                    상세 기록
+                                </div>
+                            </div>
                         </li>
                     ))}
                 </ul>

--- a/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
+++ b/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
@@ -18,6 +18,11 @@
         margin: 10% 0 0 2%;
     }
 
+    @include tablet {
+        width: 100%;
+        margin: 30px 0px;
+    }
+
     &-title {
         font-size: 20px;
         padding: 5px;
@@ -47,6 +52,10 @@
 
             @include mobile {
                 font-size: 11px;
+            }
+
+            @include tablet {
+                font-size: 13px;
             }
 
             &:hover {

--- a/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
+++ b/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
@@ -1,4 +1,5 @@
-@import 'src/assets/styles/index.scss';
+@import "src/assets/styles/index.scss";
+@import "src/assets/styles/mixins.scss";
 
 .menu {
     display: flex;
@@ -12,15 +13,24 @@
     border-radius: 10px;
     margin: 30px 40px;
 
+    @include mobile {
+        width: 90%;
+        margin: 10% 0 0 2%;
+    }
+
     &-title {
         font-size: 20px;
         padding: 5px;
         font-weight: bolder;
-        font-family: 'Poppins', sans-serif;
+        font-family: "Poppins", sans-serif;
     }
 
     &-subtitle {
         font-size: 15px;
+
+        @include mobile {
+            font-size: 13px;
+        }
     }
 
     &-cctvList {
@@ -34,6 +44,10 @@
             cursor: pointer;
             padding-bottom: 4px;
             position: relative;
+
+            @include mobile {
+                font-size: 11px;
+            }
 
             &:hover {
                 text-decoration: underline;
@@ -53,7 +67,7 @@
             left: 95%;
             top: -100%;
             padding: 2px 3px;
-            box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.20);
+            box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.2);
 
             // 말풍선 꼬리
             &::after {

--- a/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
+++ b/service/src/pages/mainPage/components/cctvSidemenu/CCTVSidemenu.scss
@@ -18,9 +18,18 @@
         margin: 10% 0 0 2%;
     }
 
+    @include tabletToMobile {
+        width: 95%;
+        margin: 10px 0;
+    }
+
     @include tablet {
         width: 100%;
         margin: 30px 0px;
+    }
+
+    @include laptopToTablet {
+        margin: 30px 20px;
     }
 
     &-title {
@@ -77,6 +86,15 @@
             top: -100%;
             padding: 2px 3px;
             box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.2);
+
+            opacity: 0;
+            transition: opacity 0.3s ease-in-out;
+            pointer-events: none;
+
+            &.visible {
+                opacity: 1;
+                pointer-events: auto;
+            }
 
             // 말풍선 꼬리
             &::after {

--- a/service/src/pages/mainPage/components/graph/Graph.scss
+++ b/service/src/pages/mainPage/components/graph/Graph.scss
@@ -1,4 +1,4 @@
-@import 'src/assets/styles/index.scss';
+@import "src/assets/styles/index.scss";
 
 .Gmenu {
     display: flex;
@@ -11,6 +11,11 @@
     border-radius: 10px;
     margin: 20px;
     padding: 10px 20px;
+
+    @include mobile {
+        width: 90%;
+        margin: 5% 0;
+    }
 
     &-container {
         display: flex;
@@ -35,5 +40,4 @@
             align-items: center;
         }
     }
-
 }

--- a/service/src/pages/mainPage/components/graph/Graph.scss
+++ b/service/src/pages/mainPage/components/graph/Graph.scss
@@ -17,6 +17,12 @@
         margin: 5% 0;
     }
 
+    @include tabletToMobile {
+        width: 95%;
+        flex-direction: row;
+        justify-content: space-around;
+    }
+
     @include tablet {
         width: 100%;
         flex-direction: row;
@@ -50,9 +56,19 @@
             display: flex;
             align-items: center;
 
+            @include tabletToMobile {
+                width: 200px;
+                height: 130px;
+            }
+
             @include tablet {
                 width: 270px;
                 height: 160px;
+            }
+
+            @include laptopToTablet {
+                width: 180px;
+                height: 110px;
             }
         }
     }

--- a/service/src/pages/mainPage/components/graph/Graph.scss
+++ b/service/src/pages/mainPage/components/graph/Graph.scss
@@ -17,6 +17,13 @@
         margin: 5% 0;
     }
 
+    @include tablet {
+        width: 100%;
+        flex-direction: row;
+        justify-content: space-around;
+        margin: 0px;
+    }
+
     &-container {
         display: flex;
         flex-direction: column;
@@ -27,6 +34,10 @@
             font-size: 13px;
             height: auto;
             padding-bottom: 5px;
+
+            @include tablet {
+                font-size: 16px;
+            }
         }
 
         .Gmenu-graph {
@@ -38,6 +49,11 @@
             background: white;
             display: flex;
             align-items: center;
+
+            @include tablet {
+                width: 270px;
+                height: 160px;
+            }
         }
     }
 }

--- a/service/src/pages/mainPage/components/header/Header.js
+++ b/service/src/pages/mainPage/components/header/Header.js
@@ -1,80 +1,90 @@
-import React, { useState, useEffect } from 'react'
-import './Header.scss'
-import defaultProfileImage from '../../../../assets/images/default_profile_image.jpg';
-import { Link, useNavigate } from 'react-router-dom';
-import api from '../../../../api/api';
+import React, { useState, useEffect } from "react";
+import "./Header.scss";
+import defaultProfileImage from "../../../../assets/images/default_profile_image.jpg";
+import { Link, useNavigate } from "react-router-dom";
+import api from "../../../../api/api";
 
 function Header({ userInfo }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
+    const [isOpen, setIsOpen] = useState(false);
+    const navigate = useNavigate();
 
-  const handleMouseEnter = () => {
-    setIsOpen(true);
-  };
+    const handleMouseEnter = () => {
+        setIsOpen(true);
+    };
 
-  const handleMouseLeave = () => {
-    setIsOpen(false);
-  };
+    const handleMouseLeave = () => {
+        setIsOpen(false);
+    };
 
-  const getRoleLabel = (roleName) => {
-    switch (roleName) {
-      case 'user':
-        return '사용자';
-      case 'manager':
-        return '매니저';
-      case 'admin':
-        return '관리자';
-      default:
-        return '';
-    }
-  };
-  // 로그아웃 처리 함수
-  const handleLogout = async () => {
-    try {
-      await api.get('/cleanguard/logout');
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-      console.log("로그아웃 완료");
-      navigate('/signup');
-    } catch (error) {
-      console.error("로그아웃 중 오류 발생:", error);
-    }
-  };
+    const getRoleLabel = (roleName) => {
+        switch (roleName) {
+            case "user":
+                return "사용자";
+            case "manager":
+                return "매니저";
+            case "admin":
+                return "관리자";
+            default:
+                return "";
+        }
+    };
+    // 로그아웃 처리 함수
+    const handleLogout = async () => {
+        try {
+            await api.get("/cleanguard/logout");
+            localStorage.removeItem("accessToken");
+            localStorage.removeItem("refreshToken");
+            console.log("로그아웃 완료");
+            navigate("/signup");
+        } catch (error) {
+            console.error("로그아웃 중 오류 발생:", error);
+        }
+    };
 
-  return (
-    <div className='header'>
-      <div
-        className='header-profileBox'
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        <div className='header-profileBox-name'>{userInfo?.name} ({getRoleLabel(userInfo?.role?.roleName)})</div>
-        <div className='header-profileBox-image'>
-          <img src={defaultProfileImage} />
+    return (
+        <div className="header">
+            <div
+                className="header-profileBox"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
+                <div className="header-profileBox-name">
+                    {userInfo?.name} ({getRoleLabel(userInfo?.role?.roleName)})
+                </div>
+                <div className="header-profileBox-image">
+                    <img src={defaultProfileImage} />
+                </div>
+
+                {/* profile 클릭 시 뜨는 dropdown 메뉴 */}
+                <div className={`dropdown ${isOpen ? "visible" : ""}`}>
+                    <div className="dropdown-profileBox">
+                        <div className="dropdown-profileBox-name">
+                            {userInfo?.name}
+                        </div>
+                        <div className="dropdown-profileBox-image">
+                            <img src={defaultProfileImage} />
+                        </div>
+                    </div>
+
+                    <div className="dropdown-linkBox">
+                        <Link to="/userinfo" className="dropdown-linkBox-text">
+                            {getRoleLabel(userInfo?.role?.roleName)}
+                        </Link>
+                        <span className="bar">|</span>
+                        <span
+                            onClick={handleLogout}
+                            className="dropdown-linkBox-text"
+                        >
+                            카카오로그인
+                        </span>
+                    </div>
+                    <button onClick={handleLogout} className="dropdown-button">
+                        로그아웃
+                    </button>
+                </div>
+            </div>
         </div>
-
-        {/* profile 클릭 시 뜨는 dropdown 메뉴 */}
-        {isOpen && (
-          <div className='dropdown'>
-            <div className='dropdown-profileBox'>
-              <div className='dropdown-profileBox-name'>{userInfo?.name}</div>
-              <div className='dropdown-profileBox-image'>
-                <img src={defaultProfileImage} />
-              </div>
-            </div>
-
-            <div className='dropdown-linkBox'>
-              <Link to="/userinfo" className='dropdown-linkBox-text'>{getRoleLabel(userInfo?.role?.roleName)}</Link>
-              <span className='bar'>|</span>
-              <span onClick={handleLogout} className='dropdown-linkBox-text'>카카오로그인</span>
-            </div>
-            <button onClick={handleLogout} className='dropdown-button'>로그아웃</button>
-          </div>
-        )}
-
-      </div>
-    </div>
-  )
+    );
 }
 
-export default Header
+export default Header;

--- a/service/src/pages/mainPage/components/header/Header.scss
+++ b/service/src/pages/mainPage/components/header/Header.scss
@@ -59,6 +59,17 @@
         width: 190px;
         height: 110px;
 
+        opacity: 0;
+        transform: translateY(-10px);
+        pointer-events: none;
+        transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+
+        &.visible {
+            opacity: 1;
+            transform: translateY(0);
+            pointer-events: auto;
+        }
+
         .bar {
             font-size: 12px;
             font-weight: bolder;

--- a/service/src/pages/mainPage/components/header/Header.scss
+++ b/service/src/pages/mainPage/components/header/Header.scss
@@ -10,6 +10,11 @@
 
     padding: 0 16px;
 
+    @include mobile {
+        height: 10%;
+        padding: 5px 0;
+    }
+
     &-profileBox {
         display: flex;
         align-items: center;
@@ -29,7 +34,7 @@
             overflow: hidden;
             cursor: pointer;
 
-            &>img {
+            & > img {
                 width: 100%;
                 height: 100%;
                 object-fit: cover;
@@ -79,7 +84,7 @@
                 border-radius: 100%;
                 overflow: hidden;
 
-                &>img {
+                & > img {
                     width: 100%;
                     height: 100%;
                     object-fit: cover;

--- a/service/src/pages/mainPage/components/log/ImageModal.scss
+++ b/service/src/pages/mainPage/components/log/ImageModal.scss
@@ -27,6 +27,10 @@
             flex-direction: column;
         }
 
+        @include tabletToMobile {
+            flex-direction: column;
+        }
+
         @include tablet {
             flex-direction: column;
         }
@@ -47,6 +51,10 @@
 
                     @include mobile {
                         height: 40%;
+                    }
+
+                    @include tabletToMobile {
+                        height: 55%;
                     }
 
                     @include tablet {
@@ -138,6 +146,11 @@
                     right: 50px;
                 }
 
+                @include tabletToMobile {
+                    position: relative;
+                    right: 7%;
+                }
+
                 @include tablet {
                     position: relative;
                     right: 7%;
@@ -173,6 +186,11 @@
                 overflow-x: auto;
             }
 
+            @include tabletToMobile {
+                width: 90%;
+                overflow-x: auto;
+            }
+
             @include tablet {
                 width: 90%;
                 overflow-x: auto;
@@ -186,6 +204,10 @@
             padding: 16px;
 
             @include mobile {
+                flex-direction: row;
+            }
+
+            @include tabletToMobile {
                 flex-direction: row;
             }
 
@@ -214,6 +236,11 @@
             @include mobile {
                 width: 120px;
                 height: 80px;
+            }
+
+            @include tabletToMobile {
+                width: 140px;
+                height: 100px;
             }
 
             @include tablet {

--- a/service/src/pages/mainPage/components/log/ImageModal.scss
+++ b/service/src/pages/mainPage/components/log/ImageModal.scss
@@ -1,4 +1,4 @@
-@import 'src/assets/styles/index.scss';
+@import "src/assets/styles/index.scss";
 
 .image {
     position: fixed;
@@ -23,6 +23,10 @@
         border-radius: 12px;
         box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
 
+        @include mobile {
+            flex-direction: column;
+        }
+
         &-body {
             width: 100%;
             flex: 1;
@@ -36,6 +40,10 @@
 
                 img {
                     user-select: none;
+
+                    @include mobile {
+                        height: 40%;
+                    }
                 }
             }
 
@@ -74,7 +82,7 @@
             padding: 0 16px;
             border-bottom: 1px solid #e6e5e5;
 
-            &>div {
+            & > div {
                 height: auto;
                 width: auto;
             }
@@ -93,6 +101,11 @@
                 background: #e6e5e5ae;
                 padding: 4px 10px;
                 border-radius: 10px;
+
+                @include mobile {
+                    position: relative;
+                    top: 50px;
+                }
             }
 
             &-time {
@@ -100,12 +113,22 @@
                 font-size: 12px;
                 color: #393939;
                 //margin-top: 4px;
+
+                @include mobile {
+                    position: relative;
+                    top: 50px;
+                }
             }
 
             &-title {
                 font-size: 15px;
                 font-weight: bold;
                 transform: translateX(-50%);
+
+                @include mobile {
+                    position: relative;
+                    right: 50px;
+                }
             }
 
             &-close {
@@ -124,8 +147,6 @@
             }
         }
 
-
-
         &-footer-wrapper {
             width: 17%;
             overflow-y: auto;
@@ -133,6 +154,11 @@
             border-bottom-right-radius: 12px;
             margin: 10px;
             height: auto;
+
+            @include mobile {
+                width: 90%;
+                overflow-x: auto;
+            }
         }
 
         &-footer {
@@ -140,6 +166,10 @@
             flex-direction: column;
             gap: 10px;
             padding: 16px;
+
+            @include mobile {
+                flex-direction: row;
+            }
         }
 
         .preview-image-container {
@@ -159,6 +189,11 @@
             border-radius: 7px;
             transition: all 0.3s ease;
 
+            @include mobile {
+                width: 120px;
+                height: 80px;
+            }
+
             &-info {
                 position: absolute;
                 width: auto;
@@ -172,7 +207,6 @@
                 margin-left: 4px;
                 margin-bottom: 4px;
             }
-
         }
 
         .preview-image.selected {

--- a/service/src/pages/mainPage/components/log/ImageModal.scss
+++ b/service/src/pages/mainPage/components/log/ImageModal.scss
@@ -27,6 +27,10 @@
             flex-direction: column;
         }
 
+        @include tablet {
+            flex-direction: column;
+        }
+
         &-body {
             width: 100%;
             flex: 1;
@@ -43,6 +47,10 @@
 
                     @include mobile {
                         height: 40%;
+                    }
+
+                    @include tablet {
+                        height: 65%;
                     }
                 }
             }
@@ -129,6 +137,11 @@
                     position: relative;
                     right: 50px;
                 }
+
+                @include tablet {
+                    position: relative;
+                    right: 7%;
+                }
             }
 
             &-close {
@@ -159,6 +172,11 @@
                 width: 90%;
                 overflow-x: auto;
             }
+
+            @include tablet {
+                width: 90%;
+                overflow-x: auto;
+            }
         }
 
         &-footer {
@@ -168,6 +186,10 @@
             padding: 16px;
 
             @include mobile {
+                flex-direction: row;
+            }
+
+            @include tablet {
                 flex-direction: row;
             }
         }
@@ -192,6 +214,11 @@
             @include mobile {
                 width: 120px;
                 height: 80px;
+            }
+
+            @include tablet {
+                width: 160px;
+                height: 120px;
             }
 
             &-info {

--- a/service/src/pages/mainPage/components/log/Log.scss
+++ b/service/src/pages/mainPage/components/log/Log.scss
@@ -7,10 +7,18 @@
     height: 5%;
     display: flex;
     position: relative;
+
+    @include mobile {
+    }
 }
 .viewer-title {
     width: auto;
     margin-right: 10px;
+
+    @include mobile {
+        margin: 0 4% 0 4%;
+        font-size: 15px;
+    }
 }
 .viewer-main-button {
     width: 75px;
@@ -24,11 +32,25 @@
     font-family: "Poppins", sans-serif;
     background-color: #fff;
     cursor: pointer;
+
+    @include mobile {
+        position: absolute;
+        left: 4%;
+        top: -70%;
+        width: 65px;
+        height: 23px;
+        font-size: 13px;
+    }
 }
 .viewer-main-button-icon {
     width: 16px;
     height: 16px;
     margin: 0px 2px 1px 6px;
+
+    @include mobile {
+        width: 13px;
+        height: 13px;
+    }
 }
 .viewer-button-group {
     width: 150px;
@@ -37,6 +59,10 @@
     position: absolute;
     right: 0px;
     z-index: 1;
+    @include mobile {
+        position: absolute;
+        left: 66%;
+    }
 }
 .viewer-button-group-action {
     width: 68px;
@@ -51,16 +77,3 @@
     padding-right: 1px;
     cursor: pointer;
 }
-
-// .sidemenu {
-//     height: 100%;
-//     display: flex;
-//     flex-direction: column;
-//     justify-content: flex-start;
-//     align-items: center;
-//     gap: 20px;
-// }
-// .sidemenu img {
-//     width: 210px;
-//     height: 137px;
-// }

--- a/service/src/pages/mainPage/components/log/Log.scss
+++ b/service/src/pages/mainPage/components/log/Log.scss
@@ -8,6 +8,10 @@
     display: flex;
     position: relative;
 
+    @include tabletToMobile {
+        width: 95%;
+    }
+
     @include tablet {
         width: 100%;
     }

--- a/service/src/pages/mainPage/components/log/Log.scss
+++ b/service/src/pages/mainPage/components/log/Log.scss
@@ -8,7 +8,8 @@
     display: flex;
     position: relative;
 
-    @include mobile {
+    @include tablet {
+        width: 100%;
     }
 }
 .viewer-title {

--- a/service/src/pages/mainPage/components/log/LogList.scss
+++ b/service/src/pages/mainPage/components/log/LogList.scss
@@ -27,7 +27,15 @@
         grid-template-rows: auto;
         row-gap: 22%;
         column-gap: 5%;
-        padding: 10% 3%;
+        padding: 5% 3%;
+    }
+
+    @include tablet {
+        width: 100%;
+        height: 100%;
+        grid-template-columns: repeat(3, 1fr);
+        row-gap: 8%;
+        column-gap: 20px;
     }
 
     /* 스크롤바 스타일 */
@@ -53,6 +61,14 @@
     position: relative;
     width: 100%;
     height: 180px;
+
+    @include mobile {
+        height: 110px;
+    }
+
+    @include tablet {
+        height: 130px;
+    }
 }
 
 .log-checkbox {
@@ -117,6 +133,14 @@
     transition: opacity 0.1s ease-in-out;
     background: rgba(0, 0, 0, 0.5);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+
+    @include mobile {
+        opacity: 0.7;
+    }
+
+    @include tablet {
+        opacity: 0.7;
+    }
 
     &:hover {
         background: rgba(0, 0, 0, 0.7);

--- a/service/src/pages/mainPage/components/log/LogList.scss
+++ b/service/src/pages/mainPage/components/log/LogList.scss
@@ -9,16 +9,26 @@
 
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: 40%;
-    row-gap: 20%;
-    column-gap: 20px;
+    // grid-template-rows: 40%;
+    grid-auto-rows: 1fr;
+    row-gap: 14%;
+    column-gap: 15px;
 
     overflow-y: scroll;
     border-radius: 8px;
     margin-top: 5px;
-    // display: flex;
-    // justify-content: space-evenly;
-    // flex-wrap: wrap;
+
+    @include mobile {
+        position: relative;
+        width: 100%;
+        height: 44%;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-rows: auto;
+        row-gap: 22%;
+        column-gap: 5%;
+        padding: 10% 3%;
+    }
 
     /* 스크롤바 스타일 */
     &::-webkit-scrollbar {
@@ -42,7 +52,7 @@
 .log-item {
     position: relative;
     width: 100%;
-    height: 100%;
+    height: 180px;
 }
 
 .log-checkbox {
@@ -86,7 +96,7 @@
 /* 로그 정보 */
 .log-info {
     width: 100%;
-    height: 15%;
+    height: auto;
     display: flex;
     flex-direction: column;
     font-size: 12px;

--- a/service/src/pages/mainPage/components/log/LogList.scss
+++ b/service/src/pages/mainPage/components/log/LogList.scss
@@ -30,6 +30,14 @@
         padding: 5% 3%;
     }
 
+    @include tabletToMobile {
+        width: 100%;
+        height: 80%;
+        grid-template-columns: repeat(3, 1fr);
+        row-gap: 15%;
+        column-gap: 10px;
+    }
+
     @include tablet {
         width: 100%;
         height: 100%;
@@ -64,6 +72,10 @@
 
     @include mobile {
         height: 110px;
+    }
+
+    @include tabletToMobile {
+        height: 120px;
     }
 
     @include tablet {
@@ -130,11 +142,15 @@
     margin: 5px;
     opacity: 0;
     border-radius: 50%;
-    transition: opacity 0.1s ease-in-out;
+    transition: opacity 0.3s ease-in-out;
     background: rgba(0, 0, 0, 0.5);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 
     @include mobile {
+        opacity: 0.7;
+    }
+
+    @include tabletToMobile {
         opacity: 0.7;
     }
 

--- a/service/src/pages/mainPage/components/videoViewer/VideoViewer.js
+++ b/service/src/pages/mainPage/components/videoViewer/VideoViewer.js
@@ -226,32 +226,34 @@ function VideoViewer({
                                     alt={`Capture ${item.imageId}`}
                                     className="slider-image"
                                 />
-
-                                {hoveredImageId === item.imageId && (
-                                    <div className="image-info">
-                                        <p>{item.cctv.location}</p>
-                                        <p>
-                                            {new Date(item.time).getFullYear()}-
-                                            {String(
-                                                new Date(item.time).getMonth() +
-                                                    1
-                                            ).padStart(2, "0")}
-                                            -
-                                            {String(
-                                                new Date(item.time).getDate()
-                                            ).padStart(2, "0")}
-                                        </p>
-                                        <p>
-                                            {String(
-                                                new Date(item.time).getHours()
-                                            ).padStart(2, "0")}
-                                            :
-                                            {String(
-                                                new Date(item.time).getMinutes()
-                                            ).padStart(2, "0")}
-                                        </p>
-                                    </div>
-                                )}
+                                <div
+                                    className={`image-info ${
+                                        hoveredImageId === item.imageId
+                                            ? "show"
+                                            : ""
+                                    }`}
+                                >
+                                    <p>{item.cctv.location}</p>
+                                    <p>
+                                        {new Date(item.time).getFullYear()}-
+                                        {String(
+                                            new Date(item.time).getMonth() + 1
+                                        ).padStart(2, "0")}
+                                        -
+                                        {String(
+                                            new Date(item.time).getDate()
+                                        ).padStart(2, "0")}
+                                    </p>
+                                    <p>
+                                        {String(
+                                            new Date(item.time).getHours()
+                                        ).padStart(2, "0")}
+                                        :
+                                        {String(
+                                            new Date(item.time).getMinutes()
+                                        ).padStart(2, "0")}
+                                    </p>
+                                </div>
                             </div>
                         ))}
                     </Slider>
@@ -313,30 +315,34 @@ function VideoViewer({
                                 alt={`Capture ${item.imageId}`}
                                 className="slider-image"
                             />
-                            {hoveredImageId === item.imageId && (
-                                <div className="image-info">
-                                    <p>{item.cctv.location}</p>
-                                    <p>
-                                        {new Date(item.time).getFullYear()}-
-                                        {String(
-                                            new Date(item.time).getMonth() + 1
-                                        ).padStart(2, "0")}
-                                        -
-                                        {String(
-                                            new Date(item.time).getDate()
-                                        ).padStart(2, "0")}
-                                    </p>
-                                    <p>
-                                        {String(
-                                            new Date(item.time).getHours()
-                                        ).padStart(2, "0")}
-                                        :
-                                        {String(
-                                            new Date(item.time).getMinutes()
-                                        ).padStart(2, "0")}
-                                    </p>
-                                </div>
-                            )}
+                            <div
+                                className={`image-info ${
+                                    hoveredImageId === item.imageId
+                                        ? "show"
+                                        : ""
+                                }`}
+                            >
+                                <p>{item.cctv.location}</p>
+                                <p>
+                                    {new Date(item.time).getFullYear()}-
+                                    {String(
+                                        new Date(item.time).getMonth() + 1
+                                    ).padStart(2, "0")}
+                                    -
+                                    {String(
+                                        new Date(item.time).getDate()
+                                    ).padStart(2, "0")}
+                                </p>
+                                <p>
+                                    {String(
+                                        new Date(item.time).getHours()
+                                    ).padStart(2, "0")}
+                                    :
+                                    {String(
+                                        new Date(item.time).getMinutes()
+                                    ).padStart(2, "0")}
+                                </p>
+                            </div>
                         </div>
                     ))}
                 </Slider>

--- a/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
+++ b/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
@@ -1,9 +1,15 @@
 @import "src/assets/styles/index.scss";
+@import "src/assets/styles/mixins.scss";
 
 .viewer {
     display: flex;
     height: 100%;
     flex-direction: column;
+
+    @include mobile {
+        grid-column: 1 / 4;
+        grid-row: 1 / 3;
+    }
 
     .multi-viewer-video-container {
         display: grid;
@@ -188,6 +194,11 @@
         border-radius: 10px;
         padding-bottom: 5px;
 
+        @include mobile {
+            width: 100%;
+            margin: 4% 0 0 0;
+        }
+
         &-button {
             position: relative;
             left: 32%;
@@ -202,6 +213,15 @@
             background-color: $primary-color;
             cursor: pointer;
             transition: background-color 0.3s ease;
+
+            @include mobile {
+                position: relative;
+                left: 25%;
+                width: 30%;
+                height: 25%;
+                font-size: 11px;
+            }
+
             &:hover {
                 background-color: $primary-hover-color;
             }
@@ -212,6 +232,11 @@
             max-height: 110px;
             max-width: 700px; // 슬라이더는 최대 700px까지만 늘어나게 제한
             margin: 0 auto;
+
+            @include mobile {
+                width: 80%;
+                height: 60%;
+            }
         }
 
         .slider-image-container {
@@ -242,6 +267,10 @@
                 align-items: flex-start;
                 max-width: 90%;
                 opacity: 1;
+
+                @include mobile {
+                    display: none;
+                }
             }
         }
 

--- a/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
+++ b/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
@@ -11,6 +11,13 @@
         grid-row: 1 / 3;
     }
 
+    @include tabletToMobile {
+        width: 80%;
+        height: 100%;
+        grid-column: 2/5;
+        grid-row: 1/5;
+    }
+
     @include tablet {
         width: 95%;
         height: 100%;
@@ -70,7 +77,7 @@
         height: 18px;
         width: 18px;
         opacity: 0;
-        transition: opacity 0.1s ease;
+        transition: opacity 0.3s ease;
     }
 
     .multi-viewer-video:hover .fullscreen-icon {
@@ -206,6 +213,12 @@
             margin: 4% 0 0 0;
         }
 
+        @include tabletToMobile {
+            width: 100%;
+            height: 10%;
+            margin: 4% 0 0 0;
+        }
+
         @include tablet {
             width: 100%;
             height: 20%;
@@ -235,6 +248,14 @@
                 font-size: 11px;
             }
 
+            @include tabletToMobile {
+                position: relative;
+                left: 25%;
+                width: 27%;
+                height: 23%;
+                font-size: 12px;
+            }
+
             @include tablet {
                 position: relative;
                 left: 27%;
@@ -257,6 +278,11 @@
             @include mobile {
                 width: 75%;
                 height: 70%;
+            }
+
+            @include tabletToMobile {
+                width: 77%;
+                height: 67%;
             }
 
             @include tablet {
@@ -292,7 +318,14 @@
                 flex-direction: column;
                 align-items: flex-start;
                 max-width: 90%;
-                opacity: 1;
+                opacity: 0;
+                transition: opacity 0.5s ease-in-out;
+                pointer-events: none;
+
+                &.show {
+                    opacity: 1;
+                    pointer-events: auto;
+                }
 
                 @include mobile {
                     display: none;

--- a/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
+++ b/service/src/pages/mainPage/components/videoViewer/VideoViewer.scss
@@ -11,6 +11,13 @@
         grid-row: 1 / 3;
     }
 
+    @include tablet {
+        width: 95%;
+        height: 100%;
+        grid-column: 2 / 5;
+        grid-row: 1 / 5;
+    }
+
     .multi-viewer-video-container {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -199,6 +206,12 @@
             margin: 4% 0 0 0;
         }
 
+        @include tablet {
+            width: 100%;
+            height: 20%;
+            margin: 4% 0 0 0;
+        }
+
         &-button {
             position: relative;
             left: 32%;
@@ -216,10 +229,18 @@
 
             @include mobile {
                 position: relative;
-                left: 25%;
+                left: 23%;
                 width: 30%;
                 height: 25%;
                 font-size: 11px;
+            }
+
+            @include tablet {
+                position: relative;
+                left: 27%;
+                width: 25%;
+                height: 20%;
+                font-size: 13px;
             }
 
             &:hover {
@@ -234,8 +255,13 @@
             margin: 0 auto;
 
             @include mobile {
+                width: 75%;
+                height: 70%;
+            }
+
+            @include tablet {
                 width: 80%;
-                height: 60%;
+                height: 65%;
             }
         }
 

--- a/service/src/pages/mainPage/main.scss
+++ b/service/src/pages/mainPage/main.scss
@@ -17,13 +17,23 @@
         max-width: 90%;
         background-color: $container-primary;
         box-shadow: 0px 2px 16px 0px rgb(0 0 0 / 16%);
+        overflow-x: auto;
+        overflow-y: auto;
 
         @include mobile {
             max-height: 95%;
         }
 
+        @include tabletToMobile {
+            padding: 0px 3%;
+        }
+
         @include tablet {
             padding: 0px 3%;
+        }
+
+        @include laptopToTablet {
+            padding: 0px 1%;
         }
     }
 
@@ -40,6 +50,15 @@
             display: grid;
             grid-template-rows: 1fr 1fr;
             grid-template-columns: 1fr 1fr 1fr;
+            gap: 2%;
+            justify-items: center;
+        }
+
+        @include tabletToMobile {
+            height: 90%;
+            display: grid;
+            grid-template-rows: 1fr 1fr 1fr 1fr 1fr;
+            grid-template-columns: 0.7fr 1fr 1fr;
             gap: 2%;
             justify-items: center;
         }
@@ -64,11 +83,23 @@
                 grid-row: 1 / 2;
             }
 
+            @include tabletToMobile {
+                width: 95%;
+                height: 100%;
+                grid-column: 2 / 5;
+                grid-row: 1 / 4;
+            }
+
             @include tablet {
                 width: 95%;
                 height: 100%;
                 grid-column: 2 / 5;
                 grid-row: 1 / 4;
+            }
+
+            @include laptopToTablet {
+                width: 50%;
+                height: 95%;
             }
         }
 
@@ -83,6 +114,11 @@
                 height: 100%;
                 grid-column: 1 / 2;
                 grid-row: 2 / 3;
+            }
+
+            @include tabletToMobile {
+                grid-column: 1 / 2;
+                grid-row: 1 / 2;
             }
 
             @include tablet {
@@ -101,6 +137,13 @@
                 height: 100%;
                 grid-column: 2 / 4;
                 grid-row: 2 / 3;
+            }
+
+            @include tabletToMobile {
+                width: 99%;
+                grid-column: 1 / 4;
+                grid-row: 4 / 6;
+                margin-left: 2%;
             }
 
             @include tablet {

--- a/service/src/pages/mainPage/main.scss
+++ b/service/src/pages/mainPage/main.scss
@@ -13,15 +13,14 @@
         flex-direction: column;
         position: relative;
         overflow: hidden;
-
-        display: flex;
-
-        // 반응형 웹으로 수정해야함
         max-height: 90%;
         max-width: 90%;
-
         background-color: $container-primary;
         box-shadow: 0px 2px 16px 0px rgb(0 0 0 / 16%);
+
+        @include mobile {
+            max-height: 95%;
+        }
     }
 
     &-content {
@@ -32,12 +31,39 @@
         // height: calc(100% - 71px);
         height: calc(100% - 85px);
 
+        @include mobile {
+            height: 90%;
+            display: grid;
+            grid-template-rows: 1fr 1fr;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 2%;
+            justify-items: center;
+        }
+
+        .video-viewer {
+            height: 100%;
+
+            @include mobile {
+                width: 90%;
+                height: 100%;
+                margin: 5px;
+                grid-column: 1 / 4;
+                grid-row: 1 / 2;
+            }
+        }
+
         .sidemenu {
             text-align: center;
             width: auto;
             align-items: flex-start;
             display: flex;
             justify-content: center;
+
+            @include mobile {
+                height: 100%;
+                grid-column: 1 / 2;
+                grid-row: 2 / 3;
+            }
         }
 
         .graph {
@@ -45,10 +71,12 @@
             display: flex;
             justify-content: center;
             width: auto;
-        }
 
-        .video-viewer {
-            height: 100%;
+            @include mobile {
+                height: 100%;
+                grid-column: 2 / 4;
+                grid-row: 2 / 3;
+            }
         }
     }
 }

--- a/service/src/pages/mainPage/main.scss
+++ b/service/src/pages/mainPage/main.scss
@@ -21,6 +21,10 @@
         @include mobile {
             max-height: 95%;
         }
+
+        @include tablet {
+            padding: 0px 3%;
+        }
     }
 
     &-content {
@@ -40,6 +44,15 @@
             justify-items: center;
         }
 
+        @include tablet {
+            height: 90%;
+            display: grid;
+            grid-template-rows: 1fr 1fr 1fr 1fr 1fr;
+            grid-template-columns: 0.7fr 1fr 1fr;
+            gap: 2%;
+            justify-items: center;
+        }
+
         .video-viewer {
             height: 100%;
 
@@ -49,6 +62,13 @@
                 margin: 5px;
                 grid-column: 1 / 4;
                 grid-row: 1 / 2;
+            }
+
+            @include tablet {
+                width: 95%;
+                height: 100%;
+                grid-column: 2 / 5;
+                grid-row: 1 / 4;
             }
         }
 
@@ -64,6 +84,11 @@
                 grid-column: 1 / 2;
                 grid-row: 2 / 3;
             }
+
+            @include tablet {
+                grid-column: 1 / 2;
+                grid-row: 1 / 2;
+            }
         }
 
         .graph {
@@ -76,6 +101,13 @@
                 height: 100%;
                 grid-column: 2 / 4;
                 grid-row: 2 / 3;
+            }
+
+            @include tablet {
+                width: 99%;
+                grid-column: 1 / 4;
+                grid-row: 4 / 6;
+                margin-left: 2%;
             }
         }
     }

--- a/service/src/pages/signupPage/signup.scss
+++ b/service/src/pages/signupPage/signup.scss
@@ -2,28 +2,58 @@
 @import "../mainPage/main.scss";
 
 .signup-main-container {
-    // 반응형 웹으로 수정해야함
     max-height: 75%;
     max-width: 25%;
     display: flex;
     flex-direction: column;
     align-items: center;
-
     position: relative;
-    overflow: hidden;
+    // overflow: hidden;
+    overflow: auto;
     background-color: $container-primary;
     box-shadow: 0px 2px 16px 0px rgb(0 0 0 / 16%);
+
+    // 모바일
+    @include mobile {
+        max-width: 75%;
+        max-height: 70%;
+    }
+    // 모바일에서 태블릿
+    @include tabletToMobile {
+        max-width: 65%;
+    }
+    // 태블릿
+    @include tablet {
+        max-width: 50%;
+    }
+    // 태블릿에서 노트북
+    @include laptopToTablet {
+        max-width: 40%;
+    }
 }
 
 /* Sign up */
 .sign-up {
     width: auto;
-    height: 12%;
+    height: auto;
     font-family: "Moul", sans-serif;
     font-size: 40px;
     font-weight: 400;
     color: $text-color;
     margin-top: 20%;
+
+    // 모바일
+    @include mobile {
+        font-size: 36px;
+    }
+    // 모바일에서 태블릿
+    @include tabletToMobile {
+        font-size: 43px;
+    }
+    // 태블릿
+    @include tablet {
+        font-size: 45px;
+    }
 }
 
 /* 회원가입 */
@@ -35,6 +65,15 @@
     font-weight: 700;
     color: $text-color;
     margin-bottom: 20px;
+
+    // 모바일에서 태블릿
+    @include tabletToMobile {
+        font-size: 20px;
+    }
+    // 태블릿
+    @include tablet {
+        font-size: 22px;
+    }
 }
 
 /* 카카오 버튼 */
@@ -56,6 +95,14 @@
 
     &:hover {
         box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+    }
+    // 모바일에서 태블릿
+    @include tabletToMobile {
+        font-size: 16px;
+    }
+    // 태블릿
+    @include tablet {
+        font-size: 18px;
     }
 }
 .kakao-login-btn-logo {

--- a/service/src/pages/userinfoPage/userinfo.scss
+++ b/service/src/pages/userinfoPage/userinfo.scss
@@ -2,18 +2,35 @@
 @import "../mainPage/main.scss";
 
 .userinfo-main-container {
-    // 반응형 웹으로 수정해야함
     max-height: 75%;
     max-width: 25%;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-
     position: relative;
-    overflow: hidden;
+    // overflow: hidden;
+    overflow: auto;
     background-color: $container-primary;
     box-shadow: 0px 2px 16px 0px rgb(0 0 0 / 16%);
+
+    // 모바일
+    @include mobile {
+        max-width: 75%;
+        max-height: 70%;
+    }
+    // 모바일에서 태블릿
+    @include tabletToMobile {
+        max-width: 65%;
+    }
+    // 태블릿
+    @include tablet {
+        max-width: 50%;
+    }
+    // 태블릿에서 노트북
+    @include laptopToTablet {
+        max-width: 40%;
+    }
 }
 
 .userinfo-form {


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## #️⃣연관된 이슈

> #6   

## 반영 브랜치

> feat/responsive-layout -> dev


## 📝작업 내용

> 1. SCSS mixin을 활용하여 다양한 화면 크기(모바일 ~ 데스크탑) 대응을 위한 반응형 미디어 쿼리 추가  

> 2. 메인 화면과 로그 화면의 모바일, 태블릿, 모바일~태블릿 레이아웃 수정 (노트북, 데스크탑 레이아웃은 수정 및 추가 필요 없음)  

> 3. LogList 디자인 수정, log item의 height 고정하여 레이아웃 안정화: 
LogList에 이미지가 45장 이상일 때, 마지막 행의 이미지 크기가 다른 행의 이미지 크기와 달라지는 문제 발생  →  해결 방법: 그리드 안의 각 아이템의 높이를 고정시켜 이미지 크기 일관성 유지

>4. main-container 영역에서 콘텐츠가 잘릴 경우에만 가로/세로 스크롤이 생기도록 CSS 수정 → 작은 모바일/태블릿 환경에서 콘텐츠가 잘릴 경우를 대비해서

>5. image-info, Header, CCTVSidemenu에 transition 효과를 적용하여 부드러운 인터랙션 제공




### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d32f4b09-528c-467a-9c74-89274e834868)
![image](https://github.com/user-attachments/assets/4714a423-1455-42c4-92b8-d0f7eaf2da09)




Close #6 